### PR TITLE
DeveloperTools-7 Back arrow from memory filling feature disappears

### DIFF
--- a/app/src/main/java/com/scythe/developertools/MainActivity.kt
+++ b/app/src/main/java/com/scythe/developertools/MainActivity.kt
@@ -11,7 +11,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        setupToolbar("Developer Tools")
+        setupToolbar(getString(R.string.app_name), baseView = true)
         val navController = findNavController(R.id.nav_fragment)
         navigation_bar.setupWithNavController(navController)
     }

--- a/app/src/main/java/com/scythe/developertools/ScytheExtensionFunctions.kt
+++ b/app/src/main/java/com/scythe/developertools/ScytheExtensionFunctions.kt
@@ -8,9 +8,9 @@ import kotlinx.android.synthetic.main.toolbar.*
  */
 infix fun Int.with(x: Int) = this.or(x)
 
-fun AppCompatActivity.setupToolbar(title: String) {
+fun AppCompatActivity.setupToolbar(title: String, baseView: Boolean = false) {
     this.setSupportActionBar(toolbar)
     this.supportActionBar?.setDisplayShowTitleEnabled(false)
-    this.supportActionBar?.setDisplayHomeAsUpEnabled(!this.isTaskRoot)
+    this.supportActionBar?.setDisplayHomeAsUpEnabled(!baseView)
     toolbar_title.text = title
 }


### PR DESCRIPTION
This commit fixes #7
- Add back arrow by default unless the view is a baseView.
- Use resource for main view title